### PR TITLE
Fix hanging-indent list marker overlap + lost indent on page-split paragraphs

### DIFF
--- a/packages/react-viewer/src/editor.tsx
+++ b/packages/react-viewer/src/editor.tsx
@@ -48877,6 +48877,9 @@ export function DocxEditorViewer({
             ),
             top: 0,
             marginRight: 0,
+            // Left-align the glyph in its hanging box (see body-paragraph twin)
+            // so a split list item's marker doesn't overlap the body text.
+            justifyContent: "flex-start",
             zIndex: 1,
             pointerEvents: "none",
           }}
@@ -49219,6 +49222,11 @@ export function DocxEditorViewer({
               ),
               top: 0,
               marginRight: 0,
+              // Left-align the marker glyph within its hanging-indent box so it
+              // sits at the number position with a gap before the text, instead
+              // of flex-end pinning it against the body text (which starts at
+              // the box's right edge) and overlapping it on split paragraphs.
+              justifyContent: "flex-start",
               zIndex: 1,
               pointerEvents: "none",
             }}

--- a/packages/react-viewer/src/editor.tsx
+++ b/packages/react-viewer/src/editor.tsx
@@ -48927,6 +48927,12 @@ export function DocxEditorViewer({
               paragraphSegmentEndLine >= paragraphSegmentTotalLines
                 ? baseParagraphStyle.marginBottom
                 : 0,
+            // See body-paragraph twin: the pretext split path positions
+            // everything absolutely, so drop the block hanging text-indent that
+            // would otherwise shift the segment left by the hanging amount.
+            ...(shouldRenderParagraphSegmentWithPretext
+              ? { textIndent: 0 }
+              : undefined),
           }
         : undefined),
       outline: "none",
@@ -49364,6 +49370,15 @@ export function DocxEditorViewer({
                 paragraphSegmentEndLine >= paragraphSegmentTotalLines
                   ? resolvedAfterSpacingPx ?? afterSpacingPx
                   : 0,
+              // The pretext split path positions the marker and every line
+              // fragment absolutely, so it does not want the block hanging
+              // `text-indent: -hanging` (which otherwise shifts the whole
+              // absolutely-positioned segment left by the hanging amount,
+              // dropping the paragraph's left indent). The clip-fallback path
+              // still renders inline and keeps the text-indent.
+              ...(shouldRenderParagraphSegmentWithPretext
+                ? { textIndent: 0 }
+                : undefined),
             }
           : resolvedBeforeSpacingPx !== undefined ||
             resolvedAfterSpacingPx !== undefined

--- a/tests/unit/split-list-marker-hanging-indent.test.ts
+++ b/tests/unit/split-list-marker-hanging-indent.test.ts
@@ -1,0 +1,129 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { DocModel, NumberingDefinitionSet } from "@extend-ai/react-docx-doc-model";
+import {
+  DocxEditorViewer,
+  useDocxEditor,
+} from "../../packages/react-viewer/src/editor";
+
+// The pretext layout (which drives the split-segment render path this test
+// covers) measures text via OffscreenCanvas. Under Vitest's node environment
+// there is no canvas, so provide a deterministic proportional-width stub; without
+// it the split falls back to the inline clip path and the pretext code is never
+// exercised.
+beforeAll(() => {
+  const makeContext = () => ({
+    font: "",
+    measureText: (text: string) => ({ width: text.length * 7 }),
+  });
+  (globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas =
+    class {
+      getContext() {
+        return makeContext();
+      }
+    };
+});
+
+// Regression test for the hanging-indent list marker on page-split paragraphs.
+//
+// When a numbered/lettered list item with a hanging indent is split across a
+// page boundary, it is rendered via the absolutely-positioned "pretext" path.
+// Two bugs made that segment render wrong:
+//   1. the marker used `justify-content: flex-end`, pinning the glyph onto the
+//      body text (marker overlapped the first word);
+//   2. the block's `text-indent: -hanging` (used by the inline path) leaked onto
+//      the absolutely-positioned segment and shifted the whole thing left by the
+//      hanging amount, dropping the paragraph's left indent.
+// The fix flex-starts the split marker and zeroes the text-indent on pretext
+// split segments (see extend-hq/react-docx#10 / #11).
+
+const NUMBERING: NumberingDefinitionSet = {
+  abstracts: [
+    {
+      abstractNumId: 0,
+      levels: [
+        {
+          ilvl: 0,
+          format: "decimal",
+          text: "(%1)",
+          suffix: "tab",
+          indent: { leftTwips: 720, hangingTwips: 720 },
+        },
+      ],
+    },
+  ],
+  instances: [{ numId: 1, abstractNumId: 0 }],
+};
+
+const SENTENCE =
+  "In the event that the transaction contemplated by this Agreement is not " +
+  "consummated, neither you nor your Representatives shall, without the prior " +
+  "written consent of the Company, use any of the Evaluation Material for any " +
+  "purpose at any time, and you shall promptly return or destroy all copies, " +
+  "extracts, and other materials containing or reflecting any Evaluation Material. ";
+
+// Each item is long enough to be TALLER than a page, which forces an
+// intra-paragraph split. Once a numbered paragraph is split, its start-line-0
+// segment (the one carrying the marker) renders via the absolutely-positioned
+// pretext path — the code path this regression covers.
+const ITEM_TEXT = SENTENCE.repeat(16);
+
+function buildNumberedListModel(itemCount: number): DocModel {
+  return {
+    nodes: Array.from({ length: itemCount }, () => ({
+      type: "paragraph" as const,
+      style: { numbering: { numId: 1, ilvl: 0 } },
+      children: [{ type: "text" as const, text: ITEM_TEXT }],
+    })),
+    metadata: {
+      sourceParts: 1,
+      warnings: [],
+      headerSections: [],
+      footerSections: [],
+      paragraphStyles: [],
+      numberingDefinitions: NUMBERING,
+    },
+  };
+}
+
+function NumberedListViewer({ model }: { model: DocModel }): React.JSX.Element {
+  const editor = useDocxEditor({ starterModel: model });
+  return React.createElement(DocxEditorViewer, { editor, mode: "read-only" });
+}
+
+function renderList(itemCount: number): string {
+  return renderToStaticMarkup(
+    React.createElement(NumberedListViewer, { model: buildNumberedListModel(itemCount) })
+  );
+}
+
+describe("split hanging-indent list marker", () => {
+  it("splits a long numbered list across a page boundary (test precondition)", () => {
+    const html = renderList(3);
+    expect(html).toContain('data-docx-paragraph-partial-line-range="true"');
+    // The split segment renders numbering marker(s) via the pretext path.
+    expect(html).toContain('data-docx-numbering-label="true"');
+  });
+
+  it("places the split-segment marker at the number position (flex-start), not on the text", () => {
+    const html = renderList(3);
+    // Only the pretext split marker is flex-start; the inline (non-split) marker
+    // stays flex-end. Its presence proves the split marker is no longer pinned
+    // onto the body text.
+    expect(html).toMatch(
+      /data-docx-numbering-label="true"[^>]*justify-content:flex-start/
+    );
+  });
+
+  it("keeps the paragraph left indent on the split segment (text-indent zeroed)", () => {
+    const html = renderList(3);
+    // The pretext split host zeroes the leaked hanging text-indent so the
+    // absolutely-positioned segment stays at the paragraph's left indent.
+    // (React serializes the numeric 0 as `text-indent:0`, no unit.) Before the
+    // fix every split host carried the negative hanging text-indent instead.
+    expect(html).toMatch(
+      /data-docx-paragraph-partial-line-range="true"[^>]*text-indent:0(?![.\d])/
+    );
+  });
+});


### PR DESCRIPTION
Fixes #10.

## Problem

When a hanging-indent numbered/lettered list item is split across a page boundary, the split segment (rendered via the pretext path in `DocxEditorViewer`) rendered incorrectly in two compounding ways:

1. **Marker overlaps the text** — the numbering marker (e.g. `(4)`) printed on top of the first word.
2. **Left indent is lost** — the whole segment sat ~one hanging-unit to the left of its non-split siblings, with the marker hanging into the page margin.

Items *not* at a page boundary render correctly, so the defect is specific to the split (pretext) render path.

## Root cause

The split path positions the numbering marker and every line fragment **absolutely**:

1. The marker box (width = hanging indent) is placed at `left: -markerBoxWidth`, i.e. its right edge is at the body-text origin, and `numberingMarkerStyle` uses `justify-content: flex-end` — so the glyph is pinned to that right edge, onto the text.
2. The paragraph block still carries `text-indent: -hanging` (used by the inline/non-split path for the first-line hang). That negative `text-indent` leaks onto the absolutely-positioned pretext content and shifts the entire segment left by the hanging amount, dropping the paragraph's left indent.

## Fix

For pretext split segments only (both the body-paragraph and table-cell render paths):

- `justify-content: flex-start` on the split-segment marker so the glyph sits at the number position with the normal gap before the text.
- `text-indent: 0` on the split-segment host so the absolutely-positioned content keeps the paragraph's left indent.

The clip-fallback split path (which renders inline) is untouched and keeps its `text-indent`.

## Result

Split list items now match their non-split siblings exactly — marker at the number position, text at the left indent, continuation lines aligned, across the page break. Verified in the playground against a multi-page hanging-indent numbered list; indent unit tests (`tests/unit/paragraph-indent-wrap.test.ts`, `pretext-*`) pass.

Happy to add a synthetic repro `.docx` / unit coverage or adjust the approach if you'd prefer the origin corrected in the layout rather than via `text-indent`.